### PR TITLE
MOP-405 Fixes invisible button on PDF signature on Samsung Android 9 and mem access crash on iOS

### DIFF
--- a/src/android/ViewLib/src/main/res/layout/signature_pad.xml
+++ b/src/android/ViewLib/src/main/res/layout/signature_pad.xml
@@ -46,6 +46,7 @@
 
         <Button
             android:id="@+id/clear_button"
+            style="@style/Widget.AppCompat.Button"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"
@@ -55,6 +56,7 @@
 
         <Button
             android:id="@+id/save_button"
+            style="@style/Widget.AppCompat.Button"
             android:layout_width="0dp"
             android:layout_weight="1"
             android:layout_height="wrap_content"

--- a/src/ios/PDFLib/PDFObjc.m
+++ b/src/ios/PDFLib/PDFObjc.m
@@ -93,7 +93,7 @@ extern uint annotStrikeoutColor;
 -(void)erase:(int)color
 {
 	int *pix = (int *)Global_dibGetData(m_dib);
-	int *pix_end = pix + Global_dibGetWidth(m_dib) * Global_dibGetHeight(m_dib) * 4;
+	int *pix_end = pix + Global_dibGetWidth(m_dib) * Global_dibGetHeight(m_dib);
 	while(pix < pix_end) *pix++ = color;
 }
 


### PR DESCRIPTION
Syncs changes made directly in mobile-native repo:

https://github.com/servicetitan/mobile-native/pull/115